### PR TITLE
fix: correctly append trailing slash

### DIFF
--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -370,7 +370,7 @@ export default class Repository {
   }
 
   get originalCachePath() {
-    return join(this._model.repoId, "original") + "/";
+    return join(this._model.repoId, "original") + (process.platform === "win32" ? "\\" : "/");
   }
 
   get status() {


### PR DESCRIPTION
Windows requires a backslash instead of a forward slash. As this variable is used in a simple string replace, this needs to be platform specific. Fixes the "original" directory and "test" directory in https://github.com/tdurieux/anonymous_github/issues/174