### PR TITLE
Document the lack of support for Jekyll

### DIFF
--- a/public/partials/faq.htm
+++ b/public/partials/faq.htm
@@ -80,6 +80,7 @@
                       </li>
                       <li>
                         Anonymous GitHub only anonymizes textual files.
+                        It does not support the use of a static site generator, such as Jekyll, with GitHub Pages (although Markdown files are converted to HTML without any special formatting).
                       </li>
                       <li>
                         Anonymous GitHub does not support files that are larger than 8Mo.

--- a/public/partials/home.htm
+++ b/public/partials/home.htm
@@ -96,7 +96,8 @@
             The reviewers can explore your repository with ease, the source code
             is highlighted, PDFs, images, Notebook are rendered. The goal is to
             make is as easy as possible for the reviewer to explore and review
-            the repository. GitHub pages are also supported.
+            the repository. <a href="https://pages.github.com">GitHub Pages</a>
+            is also supported, but not static site generators, such as Jekyll.
           </p>
         </div>
         <div class="col-md-5">


### PR DESCRIPTION
Compatibility with GitHub Pages is limited: Jekyll (and other static site generators) are not supported. This change documents this limitation on the home page and FAQs.

Although Markdown files are converted to HTML and thus accessible when anonymized GitHub Pages is enabled for the repository, the Markdown to HTML conversion includes only the content -- i.e., there is no special formatting (as would be available when using Jekyll).

For anyone who wants to use Jekyll, a potential workaround is to build the site locally and commit the generated site to the repository.

Closes #269