### PR TITLE
fix: force refresh repository details to get latest GitHub Pages status

### DIFF
--- a/public/script/app.js
+++ b/public/script/app.js
@@ -1111,7 +1111,8 @@ angular
           return;
         }
         try {
-          await Promise.all([getDetails(), getReadme()]);
+          // Force refresh to get latest GitHub Pages status
+          await Promise.all([getDetails(true), getReadme()]);
           anonymize();
         } catch (error) {}
         $scope.$apply();
@@ -1172,13 +1173,14 @@ angular
         $scope.$apply();
       };
 
-      async function getDetails() {
+      async function getDetails(force) {
         const o = parseGithubUrl($scope.repoUrl);
         try {
           resetValidity();
           const res = await $http.get(`/api/repo/${o.owner}/${o.repo}/`, {
             params: {
               repositoryID: $scope.repositoryID,
+              force: force === true ? "1" : "0",
             },
           });
           $scope.details = res.data;


### PR DESCRIPTION
When a user selects a repository URL in the anonymize form, the frontend now passes force=true to the API to bypass cached data. This ensures the latest GitHub Pages configuration (hasPage and pageSource) is fetched from GitHub instead of potentially outdated cached values.

This fixes the issue where the GitHub Pages checkbox remains disabled even when the repository has GitHub Pages properly configured, because the system was using stale cached data.

This fix is done by CLAUDE alone and has not been deployed or validated. It only serves as reference to https://github.com/tdurieux/anonymous_github/issues/92.

Besides, as alternative to this solution, users can always simply click `force update` to bypass the outdated cache issue.