### PR TITLE
Fix repositories stuck as expired after extension

### DIFF
--- a/src/server/routes/repository-private.ts
+++ b/src/server/routes/repository-private.ts
@@ -190,15 +190,32 @@ router.post(
       const newExpiration = extendExpirationDate(
         repo.model.options.expirationDate
       );
+      const reactivating = repo.status === RepositoryStatus.EXPIRED;
+      const updates: Record<string, Date> = {
+        "options.expirationDate": newExpiration,
+      };
       repo.model.options.expirationDate = newExpiration;
+      if (reactivating) {
+        repo.model.anonymizeDate = new Date();
+        updates.anonymizeDate = repo.model.anonymizeDate;
+      }
       await AnonymizedRepositoryModel.updateOne(
         { _id: repo.model._id },
-        { $set: { "options.expirationDate": newExpiration } }
+        { $set: updates }
       ).exec();
 
-      // Re-anonymize so an expired repository comes back online, mirroring the
-      // refresh flow.
-      await repo.updateIfNeeded({ force: true });
+      if (reactivating) {
+        // Expiration removes the cached files. Rebuild the saved commit
+        // directly instead of asking GitHub for the latest branch head first;
+        // that lookup can fail after the new date has already been persisted
+        // and leave the repository stuck in the expired state.
+        await repo.updateStatus(RepositoryStatus.PREPARING);
+        await downloadQueue.add(
+          repo.repoId,
+          { repoId: repo.repoId },
+          { jobId: `repo-${repo.repoId}`, attempts: 3 }
+        );
+      }
       res.json({ status: repo.status, expirationDate: newExpiration });
     } catch (error) {
       handleError(error, res, req);
@@ -424,15 +441,34 @@ function updateRepoModel(
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function hasRepositorySourceChanged(
   model: IAnonymizedRepositoryDocument,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   repoUpdate: any
 ): boolean {
   return (
     repoUpdate.source.commit != model.source.commit ||
     repoUpdate.source.branch != model.source.branch ||
     repoUpdate.fullName != model.source.repositoryName
+  );
+}
+
+/**
+ * An expired repository has had its cached files removed, so saving a valid
+ * future expiration must rebuild it even when its GitHub source is unchanged.
+ */
+export function shouldReactivateExpiredRepository(
+  model: IAnonymizedRepositoryDocument,
+  now = new Date()
+): boolean {
+  if (model.status !== RepositoryStatus.EXPIRED) return false;
+  if (model.options.expirationMode === "never") return true;
+
+  const expirationDate = model.options.expirationDate;
+  return (
+    !!expirationDate &&
+    !isNaN(expirationDate.getTime()) &&
+    expirationDate > now
   );
 }
 
@@ -461,6 +497,11 @@ router.post(
       const sourceChanged = hasRepositorySourceChanged(repo.model, repoUpdate);
 
       updateRepoModel(repo.model, repoUpdate);
+      const reactivating = shouldReactivateExpiredRepository(repo.model);
+
+      if (reactivating) {
+        repo.model.anonymizeDate = new Date();
+      }
 
       if (sourceChanged) {
         const parsedRepository = gh(repoUpdate.fullName);
@@ -553,7 +594,7 @@ router.post(
           },
         }
       ).exec();
-      if (!sourceChanged) {
+      if (!sourceChanged && !reactivating) {
         return res.json({ status: repo.status });
       }
 

--- a/test/backend-reliability.test.js
+++ b/test/backend-reliability.test.js
@@ -8,6 +8,7 @@ const {
 } = require("../src/server/routes/conference");
 const {
   hasRepositorySourceChanged,
+  shouldReactivateExpiredRepository,
 } = require("../src/server/routes/repository-private");
 const {
   processRemoveRepository,
@@ -76,6 +77,47 @@ describe("repository update source detection", function () {
       hasRepositorySourceChanged(model, {
         fullName: "other/repo",
         source: { commit: "abc123", branch: "main" },
+      })
+    ).to.equal(true);
+  });
+
+  it("rebuilds an expired repository when its expiration is in the future", function () {
+    const now = new Date("2026-08-20T00:00:00.000Z");
+    expect(
+      shouldReactivateExpiredRepository(
+        {
+          status: "expired",
+          options: {
+            expirationMode: "redirect",
+            expirationDate: new Date("2027-05-01T03:57:53.395Z"),
+          },
+        },
+        now
+      )
+    ).to.equal(true);
+  });
+
+  it("does not rebuild an expired repository with a stale expiration", function () {
+    const now = new Date("2026-08-20T00:00:00.000Z");
+    expect(
+      shouldReactivateExpiredRepository(
+        {
+          status: "expired",
+          options: {
+            expirationMode: "redirect",
+            expirationDate: new Date("2026-01-01T00:00:00.000Z"),
+          },
+        },
+        now
+      )
+    ).to.equal(false);
+  });
+
+  it("rebuilds an expired repository configured never to expire", function () {
+    expect(
+      shouldReactivateExpiredRepository({
+        status: "expired",
+        options: { expirationMode: "never" },
       })
     ).to.equal(true);
   });


### PR DESCRIPTION
Extending an expired repository could update its expiration date but leave its status as expired. The cache had already been deleted, and an option-only edit did not queue a rebuild when the GitHub source stayed unchanged.

This change queues the saved commit when an expired repository gets a valid future expiration date or is set to never expire. The extend path now skips the branch-head lookup, so a failed lookup cannot leave the new date paired with the old status.

Tests:
- 400 Mocha tests passed
- TypeScript check passed
- ESLint passed