### PR TITLE
fix: reactivate removed repositories after edits

### DIFF
--- a/src/server/routes/repository-private.ts
+++ b/src/server/routes/repository-private.ts
@@ -461,14 +461,20 @@ export function hasRepositorySourceChanged(
 }
 
 /**
- * An expired repository has had its cached files removed, so saving a valid
- * future expiration must rebuild it even when its GitHub source is unchanged.
+ * An expired or removed repository has had its cached files removed, so saving
+ * a valid future expiration must rebuild it even when its GitHub source is
+ * unchanged.
  */
-export function shouldReactivateExpiredRepository(
+export function shouldReactivateInactiveRepository(
   model: IAnonymizedRepositoryDocument,
   now = new Date()
 ): boolean {
-  if (model.status !== RepositoryStatus.EXPIRED) return false;
+  if (
+    model.status !== RepositoryStatus.EXPIRED &&
+    model.status !== RepositoryStatus.REMOVED
+  ) {
+    return false;
+  }
   if (model.options.expirationMode === "never") return true;
 
   const expirationDate = model.options.expirationDate;
@@ -504,7 +510,7 @@ router.post(
       const sourceChanged = hasRepositorySourceChanged(repo.model, repoUpdate);
 
       updateRepoModel(repo.model, repoUpdate);
-      const reactivating = shouldReactivateExpiredRepository(repo.model);
+      const reactivating = shouldReactivateInactiveRepository(repo.model);
 
       if (reactivating) {
         repo.model.anonymizeDate = new Date();

--- a/test/backend-reliability.test.js
+++ b/test/backend-reliability.test.js
@@ -8,7 +8,7 @@ const {
 } = require("../src/server/routes/conference");
 const {
   hasRepositorySourceChanged,
-  shouldReactivateExpiredRepository,
+  shouldReactivateInactiveRepository,
 } = require("../src/server/routes/repository-private");
 const {
   processRemoveRepository,
@@ -90,7 +90,7 @@ describe("repository update source detection", function () {
   it("rebuilds an expired repository when its expiration is in the future", function () {
     const now = new Date("2026-08-20T00:00:00.000Z");
     expect(
-      shouldReactivateExpiredRepository(
+      shouldReactivateInactiveRepository(
         {
           status: "expired",
           options: {
@@ -106,7 +106,7 @@ describe("repository update source detection", function () {
   it("does not rebuild an expired repository with a stale expiration", function () {
     const now = new Date("2026-08-20T00:00:00.000Z");
     expect(
-      shouldReactivateExpiredRepository(
+      shouldReactivateInactiveRepository(
         {
           status: "expired",
           options: {
@@ -121,10 +121,26 @@ describe("repository update source detection", function () {
 
   it("rebuilds an expired repository configured never to expire", function () {
     expect(
-      shouldReactivateExpiredRepository({
+      shouldReactivateInactiveRepository({
         status: "expired",
         options: { expirationMode: "never" },
       })
+    ).to.equal(true);
+  });
+
+  it("rebuilds a removed repository when its expiration is in the future", function () {
+    const now = new Date("2026-08-20T00:00:00.000Z");
+    expect(
+      shouldReactivateInactiveRepository(
+        {
+          status: "removed",
+          options: {
+            expirationMode: "remove",
+            expirationDate: new Date("2027-01-31T04:18:02.444Z"),
+          },
+        },
+        now
+      )
     ).to.equal(true);
   });
 });


### PR DESCRIPTION
Editing a removed repository saved its new configuration but left it offline. The update route only rebuilt repositories marked as expired, even though removed repositories have also lost their cached files.

Treat both removed and expired repositories as reactivation candidates when the saved expiration is valid. Add a regression test using a removed repository with a future expiration date.

Tests:
- 6 repository reactivation tests pass
- TypeScript check passes
- ESLint passes
- Full suite has 403 passing tests; 3 listener tests cannot bind to localhost in the workspace sandbox