### PR TITLE
fix: clip overflowing conference link in dashboard table

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4465,7 +4465,16 @@ textarea::selection {
 }
 .paper-table .cell-anon .anon-sub a { color: var(--ink-muted); border-bottom: 1px dotted var(--border-color); }
 .paper-table .cell-anon .anon-sub a:hover { color: var(--color); }
-.paper-table .cell-conf { font-family: var(--font-mono); font-size: 13px; color: var(--color); }
+.paper-table .cell-conf {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--color);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.paper-table .cell-conf span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .paper-table .cell-status { display: flex; flex-wrap: wrap; align-items: center; gap: 2px 8px; font-size: 14px; color: var(--color); }
 .paper-table .cell-status .status-line { display: inline-flex; align-items: center; gap: 8px; }
 .paper-table .cell-status .status-sub { flex-basis: 100%; font-size: 11px; line-height: 1.2; color: var(--ink-muted); }
@@ -5294,6 +5303,12 @@ textarea::selection {
     align-items: center;
     gap: 6px;
     text-align: left;
+  }
+  .paper-table .cell-conf {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .paper-table .cell-views.num { text-align: left; }
   .paper-table .cell-views::before {

--- a/public/partials/dashboard.htm
+++ b/public/partials/dashboard.htm
@@ -195,7 +195,7 @@
           </div>
         </div>
         <div class="cell-conf" role="cell">
-          <span ng-if="item.conference" ng-bind="item.conference"></span>
+          <span ng-if="item.conference" title="{{item.conference}}" ng-bind="item.conference"></span>
           <span class="empty-dash" ng-if="!item.conference">&mdash;</span>
         </div>
         <div class="cell-status" role="cell">

--- a/test/dashboard-conference-overflow.test.js
+++ b/test/dashboard-conference-overflow.test.js
@@ -1,0 +1,49 @@
+const { expect } = require("chai");
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Regression test for the dashboard "Conference" column overflowing into
+ * the "Status" column.
+ *
+ * Root cause: `.cell-conf` is a CSS grid item with the default
+ * `min-width: auto`, so an unbreakable long string (e.g. a conference URL)
+ * forces the grid track wider than its `minmax(140px, 1fr)` track size,
+ * visually bleeding into the next cell instead of being clipped.
+ */
+
+const cssPath = path.join(__dirname, "..", "public", "css", "style.css");
+const htmlPath = path.join(__dirname, "..", "public", "partials", "dashboard.htm");
+
+function getRuleBody(css, selector) {
+  const index = css.indexOf(selector);
+  expect(index, `selector "${selector}" not found in style.css`).to.be.greaterThan(-1);
+  const start = css.indexOf("{", index);
+  const end = css.indexOf("}", start);
+  return css.slice(start + 1, end);
+}
+
+describe("dashboard .cell-conf overflow fix", function () {
+  const css = fs.readFileSync(cssPath, "utf8");
+
+  it("clips overflowing conference text instead of letting it bleed into other cells", function () {
+    const rule = getRuleBody(css, ".paper-table .cell-conf {");
+    expect(rule).to.match(/min-width:\s*0/);
+    expect(rule).to.match(/overflow:\s*hidden/);
+    expect(rule).to.match(/text-overflow:\s*ellipsis/);
+    expect(rule).to.match(/white-space:\s*nowrap/);
+  });
+
+  it("keeps the fix in the stacked mobile layout too", function () {
+    const mobileSectionStart = css.indexOf("@media (max-width: 900px)");
+    const mobileRule = getRuleBody(css.slice(mobileSectionStart), ".paper-table .cell-conf {");
+    expect(mobileRule).to.match(/overflow:\s*hidden/);
+    expect(mobileRule).to.match(/text-overflow:\s*ellipsis/);
+    expect(mobileRule).to.match(/white-space:\s*nowrap/);
+  });
+
+  it("exposes the full conference value via a title attribute for truncated text", function () {
+    const html = fs.readFileSync(htmlPath, "utf8");
+    expect(html).to.match(/cell-conf[\s\S]*?title="\{\{item\.conference\}\}"/);
+  });
+});


### PR DESCRIPTION
## Problem

On the dashboard (`/dashboard`), the **Conference** column shows the
optional conference link/name entered when creating an anonymization.
When that value is a long URL, the text overflows the column and
visually bleeds into the **Status** column, overlapping the status
dot/label.

## Root cause

`.paper-table .cell-conf` is a cell in a CSS grid row
(`grid-template-columns: minmax(280px, 2.4fr) minmax(140px, 1fr) 140px 90px 140px 52px`).
Grid items default to `min-width: auto`, which respects the intrinsic
content size. An unbreakable string like a URL has no wrap points, so
its full-width content size wins over the `minmax(140px, 1fr)` track,
pushing/overlapping the next column instead of being constrained to
it.

## Fix

- `public/css/style.css`: give `.cell-conf` `min-width: 0` so it can
  shrink below its content size, plus `overflow: hidden`,
  `text-overflow: ellipsis`, and `white-space: nowrap` so long values
  truncate with an ellipsis instead of overflowing. Applied to both
  the desktop grid layout and the stacked mobile (`max-width: 900px`)
  layout.
- `public/partials/dashboard.htm`: added `title="{{item.conference}}"`
  to the conference `<span>` so the full value is still visible on
  hover/focus after truncation.

## Testing

- Added `test/dashboard-conference-overflow.test.js`, a regression
  test that statically asserts the `.cell-conf` rule (desktop and
  mobile) carries the overflow-safe properties and that the template
  exposes the full value via `title`. Verified it fails against the
  pre-fix CSS/HTML and passes with the fix.
- Ran the full suite (`npm test`): 405 passing. The remaining 6
  failures are pre-existing, unrelated to this change (Windows
  path-separator differences in `Storage.repoPath()` and one
  `AnonymizedFile` custom-path test) — reproduced identically on
  `main` before this change.
