### PR TITLE
fix: restore scripts and video playback on project pages

### DIFF
--- a/src/server/routes/webview.ts
+++ b/src/server/routes/webview.ts
@@ -65,7 +65,9 @@ async function webView(
   req: express.Request<{ repoId: string; path?: string[] }>,
   res: express.Response
 ) {
-  res.header("Content-Security-Policy", "sandbox allow-popups allow-forms allow-modals");
+  // Project pages need scripts and autoplay, but must stay isolated from the app.
+  // Keep allow-same-origin absent so repository documents retain an opaque origin.
+  res.header("Content-Security-Policy", "sandbox allow-scripts allow-popups allow-forms allow-modals");
   const repo = await getRepo(req, res);
   if (!repo) return;
   try {

--- a/test/production-regressions.test.js
+++ b/test/production-regressions.test.js
@@ -247,7 +247,7 @@ describe("production regressions", function () {
     expect(second.headers.ETag).not.to.equal(first.headers.ETag);
     expect(second.statusCode).not.to.equal(304);
   });
-  it("decodes webview filenames and sandboxes rendered documents", async function () {
+  it("decodes webview filenames and allows scripts without same-origin access", async function () {
     const File = require("../src/core/AnonymizedFile").default;
     const utils = require("../src/server/routes/route-utils");
     const repo = { options: { terms: [], page: true, pageSource: { path: "/", branch: "main" }, image: true }, model: { source: { branch: "main" } } };
@@ -260,6 +260,7 @@ describe("production regressions", function () {
     await handler({ path: "/repo/my%20file.html", params: { repoId: "repo" }, headers: {} }, res);
     expect(path).to.equal("my file.html");
     expect(res.headers["Content-Security-Policy"]).to.include("sandbox");
+    expect(res.headers["Content-Security-Policy"]).to.include("allow-scripts");
     expect(res.headers["Content-Security-Policy"]).not.to.include("allow-same-origin");
   });
   it("terminates the streamer response after a late upstream error", async function () {


### PR DESCRIPTION
Project pages under `/w/` stopped running JavaScript after commit 67eb836 added a CSP sandbox without `allow-scripts`. This broke script-driven video playback and also blocked declarative autoplay through the sandbox's automatic-features restriction.

Allow scripts in the webview sandbox while continuing to omit `allow-same-origin`, preserving the document's opaque origin. The regression test now requires script support as well as origin isolation. The explorer's JavaScript opt-in is unchanged.

Validation:
- 38 focused regression tests pass; TypeScript checking passes; lint has no errors and seven existing warnings.
- A local Playwright harness using the webview route reproduced blocked script-driven and declarative muted video playback with the old policy in Chromium and WebKit. Both play with the new policy, while application cookies, local storage, and parent DOM remain inaccessible.
- Full suite: 514 passing, 18 pending, three asset-build failures due to missing `ordered-read-streams` in the existing local dependencies. Fresh installation was unavailable because npm returned `ERR_INVALID_URL`; CI will validate against the lockfile.

This restores script execution and removes the sandbox autoplay restriction; normal browser autoplay rules and other opaque-origin restrictions still apply.
